### PR TITLE
Make NodeJS linter's port configurable

### DIFF
--- a/componentbuild/shared/properties.xml
+++ b/componentbuild/shared/properties.xml
@@ -179,7 +179,8 @@
 
     <property name="lint.failonerror" value="false"/>
 
-    <property name="node.jslint.url" value="http://127.0.0.1:8081/"/>
+    <property name="node.jslint.port" value="8081" />
+    <property name="node.jslint.url" value="http://127.0.0.1:${node.jslint.port}/"/>
     <property name="yuicompressor.url" value="http://127.0.0.1:${yuicompressor.port}/compress"/>
 
 </project>

--- a/componentbuild/shared/targets.xml
+++ b/componentbuild/shared/targets.xml
@@ -53,10 +53,11 @@
                 </exec>
                 <if>
                     <equals arg1="${node.status}" arg2="0"/>
-                        <then>
-                        <echo level="info">Spawning Node.js app at: ${src}</echo>
+                    <then>
+                        <echo level="info">Spawning Node.js app at: ${node.jslint.url} from ${src}</echo>
                         <exec executable="node" spawn="true" failonerror="false" searchpath="true" resolveexecutable="true">
                             <arg value="${src}"/>
+                            <arg value="${node.jslint.port}" />
                         </exec>
                     </then>
                     <else>


### PR DESCRIPTION
Previously the NodeJS-based lint service was hardcoded to 8081, which can conflict for some people. It is now configurable via node.jslint.port

It still defaults to 8081
