### PR TITLE
Move language template file to a property

### DIFF
--- a/componentbuild/shared/macrolib.xml
+++ b/componentbuild/shared/macrolib.xml
@@ -289,7 +289,7 @@
                 </else>
             </if>
 
-            <copy file="${builddir}/files/langtemplate.txt" tofile="@{dest}/${@{module}@{lang}_fullname}.js" overwrite="true" outputencoding="utf-8">
+            <copy file="${langtemplate.file}" tofile="@{dest}/${@{module}@{lang}_fullname}.js" overwrite="true" outputencoding="utf-8">
                 <filterset>
                     <filter token="LANG" value="@{lang}" />
                     <filter token="LANG_MODULE" value="lang/${@{module}@{lang}_fullname}" />

--- a/componentbuild/shared/properties.xml
+++ b/componentbuild/shared/properties.xml
@@ -106,6 +106,9 @@
         </and>
     </condition>
 	
+    <!-- Which file will be used for language template loader -->
+    <property name="langtemplate.file" value="${builddir}/files/langtemplate.txt" />
+
     <!-- component test module properties -->
     <property name="testsdir" value="./tests"/>
     <property name="tests.srcdir" value="${testsdir}/src"/>


### PR DESCRIPTION
If you want to use a different i18n loader than Y.Intl.add
you need to be able to override the template used to load
the translation files.
