### PR TITLE
Add support for compiling handlebars templates into a js file

### DIFF
--- a/componentbuild/shared/macrolib.xml
+++ b/componentbuild/shared/macrolib.xml
@@ -289,7 +289,7 @@
                 </else>
             </if>
 
-            <copy file="${builddir}/files/langtemplate.txt" tofile="@{dest}/${@{module}@{lang}_fullname}.js" overwrite="true" outputencoding="utf-8">
+            <copy file="${langtemplate.file}" tofile="@{dest}/${@{module}@{lang}_fullname}.js" overwrite="true" outputencoding="utf-8">
                 <filterset>
                     <filter token="LANG" value="@{lang}" />
                     <filter token="LANG_MODULE" value="lang/${@{module}@{lang}_fullname}" />

--- a/componentbuild/shared/macrolib.xml
+++ b/componentbuild/shared/macrolib.xml
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <project name="YuiMacroLib">
+    <macrodef name="compilehandlebars">
+        <element name="sourcefiles" optional="false" />
+        <element name="outputfile" optional="false" />
+
+        <sequential>
+            <pathconvert pathsep="' '" property="sourcefilesargs">
+                <sourcefiles />
+            </pathconvert>
+            <exec executable="${handlebars.executable}" failifexecutionfails="true" failonerror="true">
+                <arg line="'${sourcefilesargs}' -f '${outputfile}'" />
+            </exec>
+        </sequential>
+    </macrodef>
 
     <macrodef name="arrayliteral">
         <attribute name="from" />

--- a/componentbuild/shared/properties.xml
+++ b/componentbuild/shared/properties.xml
@@ -106,6 +106,9 @@
         </and>
     </condition>
 	
+    <!-- Which file will be used for language template loader -->
+    <property name="langtemplate.file" value="${builddir}/files/langtemplate.txt" />
+
     <!-- component test module properties -->
     <property name="testsdir" value="./tests"/>
     <property name="tests.srcdir" value="${testsdir}/src"/>

--- a/componentbuild/shared/properties.xml
+++ b/componentbuild/shared/properties.xml
@@ -28,6 +28,7 @@
     <property name="yuicompressor.jar" location="${builddir}/lib/yuicompressor/ant-yuicompressor-2.4.5pre2.jar" />
     <property name="yrb2jsonconsole.js" location="${builddir}/lib/yrb2json/yrb2json-console.js" />
     <property name="yrb2jsonsrc.js" location="${builddir}/lib/yrb2json/yrb2json.js" />
+    <property name="handlebars.executable" value="handlebars" />
 
     <!-- YUI Compressor arguments for JS and CSS files -->
 
@@ -59,6 +60,10 @@
     <property name="component.basedir" location="${buildfile.dir}" />
     <property name="component.jsfiles.base" location="${component.basedir}/js" />
     <property name="component.cssfiles.base" location="${component.basedir}/css" />
+
+    <property name="component.template.base" location="${component.basedir}/templates" />
+    <property name="component.template.files" value="**/*" />
+    <property name="compiled-templates.file" value="compiled-templates.js" />
 
 	<property name="component.lang.base" location="${component.basedir}/lang" />
 	

--- a/componentbuild/shared/targets.xml
+++ b/componentbuild/shared/targets.xml
@@ -34,6 +34,37 @@
         <antcall target="-lint-server"/>
     </target>
 
+    <!-- compiling handlebars templates if present -->
+    <target name="handlebars" description="Precompiles handlebars templates on /templates directory to js file">
+        <if>
+            <available file="${component.template.base}" type="dir" />
+            <then>
+                <echo level="verbose">Precompiling templates for ${component} </echo>
+                <fail>
+                    <condition>
+                        <not><resourcecontains resource="${component.basedir}/build.properties" substring="compiled-templates.js"/></not>
+                    </condition>
+Compiled templates not included in jsfiles!
+
+ERROR:
+The component ${component} uses templates, but
+'${compiled-templates.file}' is not listed in the
+'component.jsfiles' entry of 'build.properties'.
+
+Please, add it to the file:
+${component.basedir}/build.properties
+                </fail>
+        
+                <compilehandlebars>
+                    <sourcefiles>
+                        <fileset dir="${component.template.base}" includes="${component.template.files}" />
+                    </sourcefiles>
+                    <outputfile>${component.jsfiles.base}/${compiled-templates.file}</outputfile>
+                </compilehandlebars>
+            </then>
+        </if>
+    </target>
+
     <target name="-lint-server" description="Start JSLint Server" unless="lint.skip">
         <antcall target="-node">
             <param name="src" value="${builddir}/lib/jslint/jslint-node.js"/>
@@ -75,7 +106,7 @@
        <delete dir="${component.builddir}" />
     </target>
 
-    <target name="build" />
+    <target name="build" depends="handlebars" />
 
     <!-- MIN -->
     <target name="minify" description="Create component-min.js from component.js">


### PR DESCRIPTION
Detect if templates/ (configurable) directory exists and
compile the templates there into a js file (by default
compiled-templates.js). This makes all the templates of the
module directly available when loading the module.
