### PR TITLE
Add build cache to avoid rebuilding components already uptodate

### DIFF
--- a/componentbuild/shared/macrolib.xml
+++ b/componentbuild/shared/macrolib.xml
@@ -289,7 +289,7 @@
                 </else>
             </if>
 
-            <copy file="${builddir}/files/langtemplate.txt" tofile="@{dest}/${@{module}@{lang}_fullname}.js" overwrite="true" outputencoding="utf-8">
+            <copy file="${langtemplate.file}" tofile="@{dest}/${@{module}@{lang}_fullname}.js" overwrite="true" outputencoding="utf-8">
                 <filterset>
                     <filter token="LANG" value="@{lang}" />
                     <filter token="LANG_MODULE" value="lang/${@{module}@{lang}_fullname}" />

--- a/componentbuild/shared/macrolib.xml
+++ b/componentbuild/shared/macrolib.xml
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <project name="YuiMacroLib">
+    <macrodef name="compilehandlebars">
+        <element name="sourcefiles" optional="false" />
+        <element name="outputfile" optional="false" />
+
+        <sequential>
+            <pathconvert pathsep="' '" property="sourcefilesargs">
+                <sourcefiles />
+            </pathconvert>
+            <exec executable="${handlebars.executable}" failifexecutionfails="true" failonerror="true">
+                <arg line="'${sourcefilesargs}' -f '${outputfile}'" />
+            </exec>
+        </sequential>
+    </macrodef>
 
     <macrodef name="arrayliteral">
         <attribute name="from" />

--- a/componentbuild/shared/properties.xml
+++ b/componentbuild/shared/properties.xml
@@ -106,6 +106,9 @@
         </and>
     </condition>
 	
+    <!-- Which file will be used for language template loader -->
+    <property name="langtemplate.file" value="${builddir}/files/langtemplate.txt" />
+
     <!-- component test module properties -->
     <property name="testsdir" value="./tests"/>
     <property name="tests.srcdir" value="${testsdir}/src"/>

--- a/componentbuild/shared/properties.xml
+++ b/componentbuild/shared/properties.xml
@@ -28,6 +28,7 @@
     <property name="yuicompressor.jar" location="${builddir}/lib/yuicompressor/ant-yuicompressor-2.4.5pre2.jar" />
     <property name="yrb2jsonconsole.js" location="${builddir}/lib/yrb2json/yrb2json-console.js" />
     <property name="yrb2jsonsrc.js" location="${builddir}/lib/yrb2json/yrb2json.js" />
+    <property name="handlebars.executable" value="handlebars" />
 
     <!-- YUI Compressor arguments for JS and CSS files -->
 
@@ -59,6 +60,10 @@
     <property name="component.basedir" location="${buildfile.dir}" />
     <property name="component.jsfiles.base" location="${component.basedir}/js" />
     <property name="component.cssfiles.base" location="${component.basedir}/css" />
+
+    <property name="component.template.base" location="${component.basedir}/templates" />
+    <property name="component.template.files" value="**/*" />
+    <property name="compiled-templates.file" value="compiled-templates.js" />
 
 	<property name="component.lang.base" location="${component.basedir}/lang" />
 	

--- a/componentbuild/shared/targets.xml
+++ b/componentbuild/shared/targets.xml
@@ -34,6 +34,37 @@
         <antcall target="-lint-server"/>
     </target>
 
+    <!-- compiling handlebars templates if present -->
+    <target name="handlebars" description="Precompiles handlebars templates on /templates directory to js file">
+        <if>
+            <available file="${component.template.base}" type="dir" />
+            <then>
+                <echo level="verbose">Precompiling templates for ${component} </echo>
+                <fail>
+                    <condition>
+                        <not><resourcecontains resource="${component.basedir}/build.properties" substring="compiled-templates.js"/></not>
+                    </condition>
+Compiled templates not included in jsfiles!
+
+ERROR:
+The component ${component} uses templates, but
+'${compiled-templates.file}' is not listed in the
+'component.jsfiles' entry of 'build.properties'.
+
+Please, add it to the file:
+${component.basedir}/build.properties
+                </fail>
+        
+                <compilehandlebars>
+                    <sourcefiles>
+                        <fileset dir="${component.template.base}" includes="${component.template.files}" />
+                    </sourcefiles>
+                    <outputfile>${component.jsfiles.base}/${compiled-templates.file}</outputfile>
+                </compilehandlebars>
+            </then>
+        </if>
+    </target>
+
     <target name="-lint-server" description="Start JSLint Server" unless="lint.skip">
         <antcall target="-node">
             <param name="src" value="${builddir}/lib/jslint/jslint-node.js"/>
@@ -75,7 +106,7 @@
        <delete dir="${component.builddir}" />
     </target>
 
-    <target name="build" />
+    <target name="build" depends="handlebars" />
 
     <!-- MIN -->
     <target name="minify" description="Create component-min.js from component.js">

--- a/componentbuild/shared/targets.xml
+++ b/componentbuild/shared/targets.xml
@@ -2,30 +2,52 @@
 
 <project name="YuiSharedTargets">
 
-    <echo level="info">Starting Build For ${component}</echo>
-
-    <echo level="verbose">Ant Properties</echo>
-    <echo level="verbose">    Home : ${ant.home}</echo>
-    <echo level="verbose">    Ant Version : ${ant.version}</echo>
-    <echo level="verbose">    Build File : ${ant.file}</echo>
-    <echo level="verbose">Local Build Properties</echo>
-    <echo level="verbose">    version : ${yui.version}</echo>
-    <echo level="verbose">    srcdir : ${srcdir}</echo>
-    <echo level="verbose">    builddir : ${builddir}</echo>
-    <echo level="verbose">    component : ${component}</echo>
-    <echo level="verbose">    component.basefilename : ${component.basefilename}</echo>
-    <echo level="verbose">    component.basedir : ${component.basedir}</echo>
-    <echo level="verbose">    component.builddir : ${component.builddir}</echo>
-    <echo level="verbose">Global Build Properties</echo>
-    <echo level="verbose">    global.build.base : ${global.build.base}</echo>
-    <echo level="verbose">    global.build.component : ${global.build.component}</echo>
-    <echo level="verbose">    global.build.component.assets : ${global.build.component.assets}</echo>
-
     <dirname property="targets.basedir" file="${ant.file.YuiSharedTargets}"/>
     <import file="${targets.basedir}/macrolib.xml" description="Macrodef definitions - jslint, yuicompessor, registerversion" />
+    <property name="build.uptodate_file" value="${global.build.component}/.uptodate" />
 
-    <target name="all" depends="local, deploy" description="Build and Deploy to Global Build Directory" />
-    <target name="local" depends="clean, init, build, minify, lint" description="Build and Deploy to Local Build Directory" />
+    <target name="all"  description="Build and Deploy to Global Build Directory">
+        <!-- Check if any file changed since build.uptodate_file was touched -->
+        <uptodate property="build.uptodate" targetfile="${build.uptodate_file}">
+            <srcfiles dir="${component.basedir}" includes="**/*" excludes="build_tmp/" />
+        </uptodate>
+
+        <!-- check whether the component has a templates directory -->
+        <available file="${component.basedir}/templates/" type="dir" property="ilocal.templates.present" value="true"/>
+
+        <if>
+            <isset property="build.uptodate" />
+            <then>
+                <echo level="info">${component} build is uptodate, skipping...</echo>
+            </then>
+            <else>
+                <antcall target="local" />
+                <antcall target="deploy" />
+                <touch file="${build.uptodate_file}" />
+            </else>
+        </if>
+    </target>
+
+    <target name="local" depends="clean, init, build, minify, lint" description="Build and Deploy to Local Build Directory">
+        <echo level="info">Starting Build For ${component}</echo>
+
+        <echo level="verbose">Ant Properties</echo>
+        <echo level="verbose">    Home : ${ant.home}</echo>
+        <echo level="verbose">    Ant Version : ${ant.version}</echo>
+        <echo level="verbose">    Build File : ${ant.file}</echo>
+        <echo level="verbose">Local Build Properties</echo>
+        <echo level="verbose">    version : ${yui.version}</echo>
+        <echo level="verbose">    srcdir : ${srcdir}</echo>
+        <echo level="verbose">    builddir : ${builddir}</echo>
+        <echo level="verbose">    component : ${component}</echo>
+        <echo level="verbose">    component.basefilename : ${component.basefilename}</echo>
+        <echo level="verbose">    component.basedir : ${component.basedir}</echo>
+        <echo level="verbose">    component.builddir : ${component.builddir}</echo>
+        <echo level="verbose">Global Build Properties</echo>
+        <echo level="verbose">    global.build.base : ${global.build.base}</echo>
+        <echo level="verbose">    global.build.component : ${global.build.component}</echo>
+        <echo level="verbose">    global.build.component.assets : ${global.build.component.assets}</echo>
+    </target>
 
     <target name="init">
         <tstamp/>
@@ -104,6 +126,7 @@ ${component.basedir}/build.properties
 
     <target name="clean" description="Clean Local Build Directory" unless="clean.skip">
        <delete dir="${component.builddir}" />
+       <delete file="${build.uptodate_file}" />
     </target>
 
     <target name="build" depends="handlebars" />


### PR DESCRIPTION
Using ant uptodate we compare source files with a file generated
during the build to detect if the components really needs rebuild.
This decreases the build time significantly.
