### PR TITLE
Ticket #34: Builder does not find nodejs, which is already installed.

### DIFF
--- a/componentbuild/shared/macrolib.xml
+++ b/componentbuild/shared/macrolib.xml
@@ -2,6 +2,13 @@
 
 <project name="YuiMacroLib">
 
+    <!-- ANT contrib library for loops, if/else support, with property fix for FOR task -->
+    <taskdef resource="antcontrib.properties">
+        <classpath>
+            <pathelement location="${builddir}/lib/ant-contrib/ant-contrib-1.0b3-modified.jar" />
+        </classpath>
+    </taskdef>
+
     <macrodef name="arrayliteral">
         <attribute name="from" />
         <attribute name="to" />
@@ -34,7 +41,7 @@
             <arrayliteral from="component.requires" to="component.details.requires" key="requires" />
             <arrayliteral from="component.optional" to="component.details.optional" key="optional" />
             <arrayliteral from="component.after" to="component.details.after" key="after" />
-        	<arrayliteral from="component.lang" to="component.details.lang" key="lang" />
+            <arrayliteral from="component.lang" to="component.details.lang" key="lang" />
             <if>
                 <isset property="component.skinnable" />
                 <then>
@@ -202,10 +209,10 @@
                         </then>
                         <else>
                             <echo>Using Rhino. Install nodejs to improve jslint speed, or skip with -Dlint.skip=true</echo>
-                            <!-- 
-                               Need to find a way to convert fileset to args (script?) to 
+                            <!--
+                               Need to find a way to convert fileset to args (script?) to
                                avoid ' ', which will break for files with ' in them
-                               
+
                                Evaluates to the following java execution line...
                                java -r js.jar jslintconsole.js 'file1.js' 'file2.js' 'file3.js'
                             -->
@@ -217,6 +224,35 @@
                             </java>
                         </else>
                     </if>
+                </else>
+            </if>
+        </sequential>
+    </macrodef>
+
+    <macrodef name="node">
+        <attribute name="spawn" default="false" />
+        <attribute name="resultproperty" default="" description="ignored if spawn is true" />
+        <attribute name="failonerror" default="false" />
+        <attribute name="failifexecutionfails" default="true" description="ignored if spawn is true" />
+        <element name="exec-elements" implicit="true" optional="true" />
+        <sequential>
+            <if>
+                <istrue value="@{spawn}" />
+                <then>
+                    <exec executable="${node.executable}" spawn="true"
+                            failonerror="@{failonerror}"
+                            searchpath="true" resolveexecutable="true">
+                        <env key="PATH" path="${env.PATH}:${node.path}" />
+                        <exec-elements />
+                    </exec>
+                </then>
+                <else>
+                    <exec executable="${node.executable}" resultproperty="@{resultproperty}"
+                            failonerror="@{failonerror}" failifexecutionfails="@{failifexecutionfails}"
+                            searchpath="true" resolveexecutable="true">
+                        <env key="PATH" path="${env.PATH}:${node.path}" />
+                        <exec-elements />
+                    </exec>
                 </else>
             </if>
         </sequential>
@@ -246,7 +282,7 @@
         <attribute name="module" />
         <attribute name="dest" />
         <attribute name="lang" default="" />
-    	<attribute name="details" default = ""/>
+        <attribute name="details" default = ""/>
 
         <sequential>
             <if>
@@ -268,7 +304,7 @@
                     <property name="@{module}@{lang}_fullname" value="@{module}_@{lang}" />
                 </else>
             </if>
-            
+
             <if>
                 <available file="@{dir}/${@{module}@{lang}_fullname}.pres" />
                 <then>
@@ -302,7 +338,7 @@
         </sequential>
 
     </macrodef>
-	
+
     <macrodef name="addmodule">
         <attribute name="file" />
         <attribute name="module" />
@@ -361,25 +397,25 @@
 
     <macrodef name="addlangrollup">
 
-    	<attribute name="module" />
+        <attribute name="module" />
         <attribute name="dir" />
 
         <sequential>
             <echo level="verbose">Registering rollup info for lang files in @{dir} using YUI.add</echo>
 
-        	<for list="${component.rollup.lang}" param="lang" trim="true">
+            <for list="${component.rollup.lang}" param="lang" trim="true">
                 <sequential>
                     <loadfile srcfile="@{dir}/@{module}_@{lang}.js" property="@{module}-@{lang}-code" />
 
                     <var name="lang.use" value="{use:[" />
 
-                    <for list="${component.lang.use}" param="submod" trim="true">                   
+                    <for list="${component.lang.use}" param="submod" trim="true">
                        <sequential>
                              <var name="lang.use" value="${lang.use}'lang/@{submod}_@{lang}'," />
                        </sequential>
                     </for>
 
-                	<var name="lang.use" value="${lang.use}]}" />
+                    <var name="lang.use" value="${lang.use}]}" />
 
                     <propertyregex property="@{module}-@{lang}-details"
                       input="${lang.use}"
@@ -395,13 +431,13 @@
                             <filter token="DETAILS" value=", ${@{module}-@{lang}-details}"/>
                         </filterset>
                     </copy>
-        		</sequential>
-        	</for>
+                </sequential>
+            </for>
 
             <loadfile srcfile="@{dir}/@{module}.js" property="@{module}--code" />
 
             <var name="lang.use" value="{use:[" />
-            <for list="${component.lang.use}" param="submod" trim="true">                   
+            <for list="${component.lang.use}" param="submod" trim="true">
                <sequential>
                      <var name="lang.use" value="${lang.use}'lang/@{submod}'," />
                </sequential>
@@ -440,6 +476,6 @@
             <echo level="verbose">Adding CSS Registration Code to @{file}</echo>
             <concat destfile="@{file}" append="true" fixlastline="true">${@{module}}</concat>
         </sequential>
-    </macrodef>    
-	
+    </macrodef>
+
 </project>

--- a/componentbuild/shared/properties.xml
+++ b/componentbuild/shared/properties.xml
@@ -11,6 +11,8 @@
 
     <dirname property="buildfile.dir" file="${ant.file}" />
 
+    <property environment="env"/>
+
     <!--
         builddir : The path to the builder/componentbuild directory from the component build file
         srcdir   : The path to top of the project source directory (e.g. yui2) from the component build file
@@ -179,6 +181,8 @@
 
     <property name="lint.failonerror" value="false"/>
 
+    <property name="node.executable" value="node"/>
+    <property name="node.path" value=""/>
     <property name="node.jslint.url" value="http://127.0.0.1:8081/"/>
     <property name="yuicompressor.url" value="http://127.0.0.1:${yuicompressor.port}/compress"/>
 

--- a/componentbuild/shared/targets.xml
+++ b/componentbuild/shared/targets.xml
@@ -48,18 +48,16 @@
             <then>
                 <!-- You can't set failifexecutionfails if spawn is true. Argh. -->
                 <!-- Check if it's installed first. -->
-                <exec resultproperty="node.status" executable="${node.executable}" failonerror="false" failifexecutionfails="false" searchpath="true" resolveexecutable="true">
-                    <env key="PATH" path="${env.PATH}:${node.path}"/>
+                <node resultproperty="node.status" failifexecutionfails="false">
                     <arg value="-v"/>
-                </exec>
+                </node>
                 <if>
                     <equals arg1="${node.status}" arg2="0"/>
                         <then>
                         <echo level="info">Spawning Node.js app at: ${src}</echo>
-                        <exec executable="${node.executable}" spawn="true" failonerror="false" searchpath="true" resolveexecutable="true">
-                            <env key="PATH" path="${env.PATH}:${node.path}"/>
+                        <node spawn="true">
                             <arg value="${src}"/>
-                        </exec>
+                        </node>
                     </then>
                     <else>
                         <echo level="info">For faster builds, install Node.js.</echo>
@@ -82,18 +80,18 @@
     <!-- MIN -->
     <target name="minify" description="Create component-min.js from component.js">
         <yuicompress src="${component.builddir}/${component.basefilename}.js" dest="${component.builddir}/${component.basefilename}-min.js" args="${yuicompressor.js.args.internal}" />
-    	<if>
+        <if>
             <available file="${component.builddir}/lang" type="dir" />
-    	    <then>
-    	    	<for param="file">
-    	    	    <path>
-    	    	      <fileset dir="${component.builddir}/lang" includes="*.js"/>
-    	    	    </path>
-    	    	    <sequential>
-    	    	       <yuicompress src="@{file}" dest="@{file}" args="${yuicompressor.js.args.internal}" />
-    	    	    </sequential>
-    	    	</for>
-    	    </then>
+            <then>
+                <for param="file">
+                    <path>
+                      <fileset dir="${component.builddir}/lang" includes="*.js"/>
+                    </path>
+                    <sequential>
+                       <yuicompress src="@{file}" dest="@{file}" args="${yuicompressor.js.args.internal}" />
+                    </sequential>
+                </for>
+            </then>
         </if>
     </target>
 
@@ -146,7 +144,7 @@
     <target name="deployskins" if="skins.exist">
         <for param="skin.dir">
             <path>
-                <dirset dir="${component.assets.base}/skins/" includes="*"/> 
+                <dirset dir="${component.assets.base}/skins/" includes="*"/>
             </path>
             <sequential>
                 <basename property="skin.name" file="@{skin.dir}"/>
@@ -158,15 +156,15 @@
                 <copy todir="${global.build.component.assets}/skins/${skin.name}" overwrite="true" verbose="false">
                     <fileset dir="${component.assets.skins.base}/${skin.name}" includes="${component.assets.skins.files}" />
                 </copy>
-		<var name="skin.name" unset="true" />
-            </sequential> 
+                <var name="skin.name" unset="true" />
+            </sequential>
         </for>
     </target>
 
     <target name="deploylang" description="Copy language bundles to global build location">
-    	<if>
+        <if>
             <available file="${component.builddir}/lang" type="dir" />
-    	    <then>
+            <then>
                 <copy todir="${global.build.component}/lang" overwrite="true" failonerror="false">
                     <fileset dir="${component.builddir}/lang" includes="*.js" />
                 </copy>

--- a/componentbuild/shared/targets.xml
+++ b/componentbuild/shared/targets.xml
@@ -48,14 +48,16 @@
             <then>
                 <!-- You can't set failifexecutionfails if spawn is true. Argh. -->
                 <!-- Check if it's installed first. -->
-                <exec resultproperty="node.status" executable="node" failonerror="false" failifexecutionfails="false" searchpath="true" resolveexecutable="true">
+                <exec resultproperty="node.status" executable="${node.executable}" failonerror="false" failifexecutionfails="false" searchpath="true" resolveexecutable="true">
+                    <env key="PATH" path="${env.PATH}:${node.path}"/>
                     <arg value="-v"/>
                 </exec>
                 <if>
                     <equals arg1="${node.status}" arg2="0"/>
                         <then>
                         <echo level="info">Spawning Node.js app at: ${src}</echo>
-                        <exec executable="node" spawn="true" failonerror="false" searchpath="true" resolveexecutable="true">
+                        <exec executable="${node.executable}" spawn="true" failonerror="false" searchpath="true" resolveexecutable="true">
+                            <env key="PATH" path="${env.PATH}:${node.path}"/>
                             <arg value="${src}"/>
                         </exec>
                     </then>


### PR DESCRIPTION
1. Added `node.executable` and `node.path` properties, preserving the existing behavior as the default.
2. Sourced the execution environment so the existing `PATH` variable could be augmented.

Fixes [#34](http://yuilibrary.com/projects/builder/ticket/34).
